### PR TITLE
Give CustomComponent access to notification data

### DIFF
--- a/src/components/Notifs.js
+++ b/src/components/Notifs.js
@@ -18,7 +18,14 @@ const Notifs = (props) => {
 
   const renderedNotifications = notifications.map((notification) => {
     if (CustomComponent) {
-      return <CustomComponent key={getter(notification, 'id')} {...props} />;
+      return <CustomComponent 
+        {...props}
+        componentClassName={componentClassName}
+        key={getter(notification, 'id')}
+        id={getter(notification, 'id')}
+        message={getter(notification, 'message')}
+        kind={getter(notification, 'kind')}
+      />;
     }
 
     return (


### PR DESCRIPTION
In commit 0bfe722055313bcbf4ece99cb2c6f8443f412b54, the rendering of `CustomComponent` was moved from within Notif.js to Notifs.js. This refactoring led to `CustomComponents` now being passed the `props` of the `Notifs` object, rather than the `Notif` object. That means that things like the `id`, `message`, etc. are no longer accessible inside the `CustomComponent`

This commit ensures that the same `props` that would be passed to a `Notif` are passed to a `CustomComponent`.