### PR TITLE
Allow HTML/React elements in message content

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ class Demo extends React.Component {
 
 #### `actions.notifSend({config})`
 
-##### `config.message : string` [required]
-> The notification message.
+##### `config.message : node` [required]
+> The notification message, can be one of: `string`, `integer`, `element` or `array` containing these types.
 
 ##### `config.kind : string` [optional] [default:'info']
 > The notification kind, can be one of: `info`, `success`, `warning`, `danger`.

--- a/src/components/Notif.js
+++ b/src/components/Notif.js
@@ -36,7 +36,7 @@ Notif.propTypes = {
     React.PropTypes.string,
     React.PropTypes.number,
   ]).isRequired,
-  message: React.PropTypes.string.isRequired,
+  message: React.PropTypes.node.isRequired,
   kind: React.PropTypes.oneOf([
     'success',
     'info',


### PR DESCRIPTION
More information about PropTypes.node here: https://facebook.github.io/react/docs/typechecking-with-proptypes.html

ATM passing HTML/React produces validation error in console. Regardless that everything seems working smoothly.