### PR TITLE
remove import of styles.css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 .DS_Store
 *.log
 node_modules
-dist
 dist_demo
-lib
 yarn.lock

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ import { Notifs } from 'redux-notifications';
 
 To import the default stylesheet:
 ```js
-import { styles } from 'redux-notifications';
+import 'redux-notifications/lib/styles.css';
 ```
 
 ## Sending notifications

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -1,0 +1,49 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.notifSend = notifSend;
+exports.notifDismiss = notifDismiss;
+exports.notifClear = notifClear;
+var NOTIF_SEND = exports.NOTIF_SEND = 'NOTIF_SEND';
+var NOTIF_DISMISS = exports.NOTIF_DISMISS = 'NOTIF_DISMISS';
+var NOTIF_CLEAR = exports.NOTIF_CLEAR = 'NOTIF_CLEAR';
+
+/**
+ * Publish a notification,
+ * - if `dismissAfter` was set, the notification will be auto dismissed after the given period.
+ * - if id wasn't specified, a time based id will be generated.``
+ */
+function notifSend(notif) {
+  var payload = Object.assign({}, notif);
+  if (!payload.id) {
+    payload.id = new Date().getTime();
+  }
+  return function (dispatch) {
+    dispatch({ type: NOTIF_SEND, payload: payload });
+
+    if (payload.dismissAfter) {
+      setTimeout(function () {
+        dispatch({
+          type: NOTIF_DISMISS,
+          payload: payload.id
+        });
+      }, payload.dismissAfter);
+    }
+  };
+}
+
+/**
+ * Dismiss a notification by the given id.
+ */
+function notifDismiss(id) {
+  return { type: NOTIF_DISMISS, payload: id };
+}
+
+/**
+ * Clear all notifications
+ */
+function notifClear() {
+  return { type: NOTIF_CLEAR };
+}

--- a/lib/components/Notif.js
+++ b/lib/components/Notif.js
@@ -1,0 +1,70 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var Notif = function Notif(_ref) {
+  var kind = _ref.kind,
+      componentClassName = _ref.componentClassName,
+      actionLabel = _ref.actionLabel,
+      onActionClick = _ref.onActionClick,
+      id = _ref.id,
+      message = _ref.message;
+
+  var handleActionClick = function handleActionClick(ev) {
+    ev.preventDefault();
+
+    if (!onActionClick) {
+      return;
+    }
+
+    onActionClick(id);
+  };
+
+  return _react2.default.createElement(
+    'div',
+    { className: componentClassName + ' ' + componentClassName + '--' + kind },
+    _react2.default.createElement('div', { className: componentClassName + '__icon' }),
+    _react2.default.createElement(
+      'div',
+      { className: componentClassName + '__content' },
+      _react2.default.createElement(
+        'span',
+        { className: componentClassName + '__message' },
+        message
+      )
+    ),
+    actionLabel && _react2.default.createElement(
+      'span',
+      { className: componentClassName + '__action' },
+      _react2.default.createElement(
+        'button',
+        { onClick: handleActionClick },
+        actionLabel
+      )
+    ),
+    _react2.default.createElement('div', { className: componentClassName + '__close' })
+  );
+};
+
+Notif.defaultProps = {
+  kind: 'info'
+};
+
+Notif.propTypes = {
+  id: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.number]).isRequired,
+  message: _react2.default.PropTypes.string.isRequired,
+  kind: _react2.default.PropTypes.oneOf(['success', 'info', 'warning', 'danger']).isRequired,
+  componentClassName: _react2.default.PropTypes.string,
+  onActionClick: _react2.default.PropTypes.func,
+  actionLabel: _react2.default.PropTypes.string
+};
+
+exports.default = Notif;

--- a/lib/components/Notifs.js
+++ b/lib/components/Notifs.js
@@ -1,0 +1,96 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _reactRedux = require('react-redux');
+
+var _reactAddonsCssTransitionGroup = require('react-addons-css-transition-group');
+
+var _reactAddonsCssTransitionGroup2 = _interopRequireDefault(_reactAddonsCssTransitionGroup);
+
+var _Notif = require('./Notif');
+
+var _Notif2 = _interopRequireDefault(_Notif);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+// This checks to see if object is immutable and properly access it
+var getter = function getter(obj, propName) {
+  return obj.get ? obj.get(propName) : obj[propName];
+};
+
+var Notifs = function Notifs(props) {
+  var notifications = props.notifications,
+      className = props.className,
+      componentClassName = props.componentClassName,
+      CustomComponent = props.CustomComponent,
+      transitionEnterTimeout = props.transitionEnterTimeout,
+      transitionLeaveTimeout = props.transitionLeaveTimeout;
+
+
+  var renderedNotifications = notifications.map(function (notification) {
+    if (CustomComponent) {
+      return _react2.default.createElement(CustomComponent, _extends({}, props, {
+        componentClassName: componentClassName,
+        key: getter(notification, 'id'),
+        id: getter(notification, 'id'),
+        message: getter(notification, 'message'),
+        kind: getter(notification, 'kind')
+      }));
+    }
+
+    return _react2.default.createElement(_Notif2.default, _extends({}, props, {
+      componentClassName: componentClassName,
+      key: getter(notification, 'id'),
+      id: getter(notification, 'id'),
+      message: getter(notification, 'message'),
+      kind: getter(notification, 'kind')
+    }));
+  });
+  var classes = [componentClassName + '__container', className].join(' ').split();
+
+  return _react2.default.createElement(
+    'div',
+    { className: classes },
+    _react2.default.createElement(
+      _reactAddonsCssTransitionGroup2.default,
+      {
+        transitionName: componentClassName + '-transition',
+        transitionEnterTimeout: transitionEnterTimeout,
+        transitionLeaveTimeout: transitionLeaveTimeout
+      },
+      renderedNotifications
+    )
+  );
+};
+
+Notifs.defaultProps = {
+  className: null,
+  componentClassName: 'notif',
+  CustomComponent: null,
+  transitionEnterTimeout: 600,
+  transitionLeaveTimeout: 600
+};
+
+Notifs.propTypes = {
+  notifications: _react2.default.PropTypes.array.isRequired,
+  className: _react2.default.PropTypes.string,
+  CustomComponent: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.func, _react2.default.PropTypes.node, _react2.default.PropTypes.element]),
+  componentClassName: _react2.default.PropTypes.string,
+  transitionEnterTimeout: _react2.default.PropTypes.number,
+  transitionLeaveTimeout: _react2.default.PropTypes.number
+};
+
+function mapStateToProps(state) {
+  return { notifications: state.get ? state.get('notifs') : state.notifs };
+}
+
+exports.default = (0, _reactRedux.connect)(mapStateToProps)(Notifs);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,26 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.reducer = exports.actions = exports.Notifs = undefined;
+
+var _reducer = require('./reducer');
+
+var _reducer2 = _interopRequireDefault(_reducer);
+
+var _actions = require('./actions');
+
+var actions = _interopRequireWildcard(_actions);
+
+var _Notifs = require('./components/Notifs');
+
+var _Notifs2 = _interopRequireDefault(_Notifs);
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.Notifs = _Notifs2.default;
+exports.actions = actions;
+exports.reducer = _reducer2.default;

--- a/lib/reducer.js
+++ b/lib/reducer.js
@@ -1,0 +1,33 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = notifs;
+
+var _actions = require('./actions');
+
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
+
+function notifs() {
+  var domain = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
+  var action = arguments[1];
+
+  if (!action || !action.type) return domain;
+
+  switch (action.type) {
+    case _actions.NOTIF_SEND:
+      return [action.payload].concat(_toConsumableArray(domain.filter(function (_ref) {
+        var id = _ref.id;
+        return id !== action.payload.id;
+      })));
+    case _actions.NOTIF_DISMISS:
+      return domain.filter(function (notif) {
+        return notif.id !== action.payload;
+      });
+    case _actions.NOTIF_CLEAR:
+      return [];
+    default:
+      return domain;
+  }
+}

--- a/lib/styles.css
+++ b/lib/styles.css
@@ -1,0 +1,57 @@
+.notif-transition-enter {
+  opacity    : 0.01;
+  transition : opacity .5s ease-in;
+}
+
+.notif-transition-enter-active {
+  opacity : 1;
+}
+
+.notif-transition-leave {
+  opacity    : 1;
+  transition : opacity .5s ease-in;
+}
+
+.notif-transition-leave-active {
+  opacity : 0.01;
+}
+
+.notif {
+  position      : relative;
+  font          : 1rem normal Helvetica, sans-serif;
+  overflow      : hidden;
+  border-radius : 4px;
+  margin-bottom : 2px;
+  max-height    : 400px;
+  box-sizing    : border-box;
+  box-shadow    : 0 0 1px 1px rgba(10, 10, 11, .125);
+  padding       : 0.5rem;
+  color         : #fff;
+}
+
+.notif--success {
+  background-color: #64ce83;
+}
+
+.notif--info {
+  background-color: #3ea2ff;
+}
+
+.notif--warning {
+  background-color: #ff7f48;
+}
+
+.notif--danger {
+  background-color: #e74c3c;
+}
+
+.notif__container {
+  position  : fixed;
+  top       : 10px;
+  right     : 0;
+  left      : 0;
+  z-index   : 1000;
+  width     : 80%;
+  max-width : 400px;
+  margin    : auto;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,9 @@
 import reducer from './reducer';
 import * as actions from './actions';
 import Notifs from './components/Notifs';
-import styles from './styles.css';
 
 export {
   Notifs,
   actions,
-  reducer,
-  styles,
+  reducer
 };


### PR DESCRIPTION
Importing styles.css is breaking non webpack builds as well as Universal/Isomorphic server apps 

This PR changes imports to directly from the lib folder (as done by other libraries like https://github.com/airbnb/react-dates)