### PR TITLE
remove import of styles.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ import { Notifs } from 'redux-notifications';
 
 To import the default stylesheet:
 ```js
-import { styles } from 'redux-notifications';
+import 'redux-notifications/lib/styles.css';
 ```
 
 ## Sending notifications

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,9 @@
 import reducer from './reducer';
 import * as actions from './actions';
 import Notifs from './components/Notifs';
-import styles from './styles.css';
 
 export {
   Notifs,
   actions,
-  reducer,
-  styles,
+  reducer
 };


### PR DESCRIPTION
Importing styles.css is breaking non webpack builds as well as Universal/Isomorphic server apps

This PR changes imports to directly from the lib folder (as done by other libraries like https://github.com/airbnb/react-dates)