### PR TITLE
Migrating from React.PropTypes

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { render } from 'react-dom';
 import { Provider, connect } from 'react-redux';
 import { createStore, compose, combineReducers, applyMiddleware } from 'redux';
@@ -26,9 +27,9 @@ function CustomNotif(props) {
   );
 }
 CustomNotif.propTypes = {
-  id: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
-  message: React.PropTypes.string,
-  onActionClick: React.PropTypes.func,
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  message: PropTypes.string,
+  onActionClick: PropTypes.func,
 };
 
 // React component
@@ -200,9 +201,9 @@ class Demo extends Component {
   }
 }
 Demo.propTypes = {
-  notifSend: React.PropTypes.func,
-  notifClear: React.PropTypes.func,
-  notifDismiss: React.PropTypes.func,
+  notifSend: PropTypes.func,
+  notifClear: PropTypes.func,
+  notifDismiss: PropTypes.func,
 };
 
 // Store:

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint-plugin-jsx-a11y": "^1.5.5",
     "eslint-plugin-react": "^5.2.0",
     "express": "^4.14.0",
+    "prop-types": "^15.5.10",    
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-redux": "^4.0.0",

--- a/src/components/Notif.js
+++ b/src/components/Notif.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const Notif = ({ kind, componentClassName, actionLabel, onActionClick, id, message }) => {
   const handleActionClick = (ev) => {
@@ -32,20 +33,20 @@ Notif.defaultProps = {
 };
 
 Notif.propTypes = {
-  id: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.number,
+  id: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
   ]).isRequired,
-  message: React.PropTypes.node.isRequired,
-  kind: React.PropTypes.oneOf([
+  message: PropTypes.node.isRequired,
+  kind: PropTypes.oneOf([
     'success',
     'info',
     'warning',
     'danger',
   ]).isRequired,
-  componentClassName: React.PropTypes.string,
-  onActionClick: React.PropTypes.func,
-  actionLabel: React.PropTypes.string,
+  componentClassName: PropTypes.string,
+  onActionClick: PropTypes.func,
+  actionLabel: PropTypes.string,
 };
 
 export default Notif;

--- a/src/components/Notifs.js
+++ b/src/components/Notifs.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 import Notif from './Notif';
+import PropTypes from 'prop-types';
 
 // This checks to see if object is immutable and properly access it
 const getter = (obj, propName) => (obj.get ? obj.get(propName) : obj[propName]);
@@ -67,16 +68,16 @@ Notifs.defaultProps = {
 };
 
 Notifs.propTypes = {
-  notifications: React.PropTypes.array.isRequired,
-  className: React.PropTypes.string,
-  CustomComponent: React.PropTypes.oneOfType([
-    React.PropTypes.func,
-    React.PropTypes.node,
-    React.PropTypes.element,
+  notifications: PropTypes.array.isRequired,
+  className: PropTypes.string,
+  CustomComponent: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.node,
+    PropTypes.element,
   ]),
-  componentClassName: React.PropTypes.string,
-  transitionEnterTimeout: React.PropTypes.number,
-  transitionLeaveTimeout: React.PropTypes.number,
+  componentClassName: PropTypes.string,
+  transitionEnterTimeout: PropTypes.number,
+  transitionLeaveTimeout: PropTypes.number,
 };
 
 function mapStateToProps(state) {


### PR DESCRIPTION
#57

add prop-types
React.PropTypes replace by PropTypes

[migrating-from-react.proptypes](https://facebook.github.io/react/blog/#migrating-from-react.proptypes)

 